### PR TITLE
converted the main path from array to string.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
   "bugs": {
     "url": "https://github.com/Haixing-Hu/vue-datetime-picker/issues"
   },
-  "main": [
-    "src/vue-datetime-picker.js"
-  ],
+  "main": "src/vue-datetime-picker.js",
   "configs": {
     "directories": {
       "dist": "dist",


### PR DESCRIPTION
i tried to use this package and bundled it using browserify but it returns this error:
```
path.js:7
    throw new TypeError('Path must be a string. Received ' + inspect(path));
    ^

TypeError: Path must be a string. Received [ 'src/vue-datetime-picker.js' ]
```