### PR TITLE
main field in package.json should be string, not array

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
   "bugs": {
     "url": "https://github.com/Haixing-Hu/vue-datetime-picker/issues"
   },
-  "main": [
-    "src/vue-datetime-picker.js"
-  ],
+  "main": "src/vue-datetime-picker.js",
   "configs": {
     "directories": {
       "dist": "dist",


### PR DESCRIPTION
When `vue-datetime-picker` has been installed using npm, webpack cannot load the module using the provided syntax, `require("vue-datetime-picker")`.  Webpack produces the following error:

    ERROR in ./~/babel-loader?presets[]=es2015&plugins[]=transform-runtime&comments=false!./~/vue-loader/lib/selector.js?type=script&index=0!./components/FooPage.vue
    Module not found: Error: Cannot resolve module 'vue-datetime-picker' in /home/amoe/werk/customer-cms/demo/vue-webpack-demo/components
     @ ./~/babel-loader?presets[]=es2015&plugins[]=transform-runtime&comments=false!./~/vue-loader/lib/selector.js?type=script&index=0!./components/FooPage.vue 8:31-61

This change fixes this error.